### PR TITLE
Element info fixed to point to real GitHub repo

### DIFF
--- a/login-box.html
+++ b/login-box.html
@@ -13,7 +13,7 @@ and password).
 @element login-box
 @blurb Login box
 @status alpha
-@homepage http://polymerlabs.github.io/login-box
+@homepage https://github.com/Adracus/login-box
 -->
 <polymer-element name="login-box" attributes="heading identification">
 


### PR DESCRIPTION
Nice job! :)

The Home page was not correct here:
https://adracus.github.io/login-box/components/login-box/
